### PR TITLE
Improve readability of hash rate

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -320,7 +320,7 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------------
-  uint64_t miner::get_speed() const
+  double miner::get_speed() const
   {
     if(is_mining()) {
       return m_current_hash_rate;

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -69,7 +69,7 @@ namespace cryptonote
     bool set_block_template(const block& bl, const difficulty_type& diffic, uint64_t height);
     bool on_block_chain_update();
     bool start(const account_public_address& adr, const boost::thread::attributes& attrs, bool do_background = false, bool ignore_battery = false);
-    uint64_t get_speed() const;
+    double get_speed() const;
     uint32_t get_threads_count() const;
     void send_stop_signal();
     bool stop();
@@ -139,7 +139,7 @@ namespace cryptonote
     miner_config m_config;
     std::string m_config_folder_path;
     std::atomic<uint64_t> m_last_hr_merge_time;
-    std::atomic<uint64_t> m_hashes;
+    double m_hashes;
     std::atomic<uint64_t> m_cumul_hashes;
     std::atomic<double> m_current_hash_rate;
     epee::critical_section m_last_hash_rates_lock;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1320,7 +1320,7 @@ skip:
     std::vector<boost::uuids::uuid> alive_peers;
     m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
     {
-      if (context.m_state == cryptonote_connection_context::normal)
+      if (context.m_state == cryptonote_connection_context::state_normal)
       {
           alive_peers.push_back(context.m_connection_id);
       }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -329,7 +329,7 @@ bool t_rpc_command_executor::show_difficulty() {
   return true;
 }
 
-static std::string get_mining_speed(uint64_t hr)
+static std::string get_mining_speed(double hr)
 {
   if (hr>1e9) return (boost::format("%.2f GH/s") % (hr/1e9)).str();
   if (hr>1e6) return (boost::format("%.2f MH/s") % (hr/1e6)).str();

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -334,7 +334,7 @@ static std::string get_mining_speed(uint64_t hr)
   if (hr>1e9) return (boost::format("%.2f GH/s") % (hr/1e9)).str();
   if (hr>1e6) return (boost::format("%.2f MH/s") % (hr/1e6)).str();
   if (hr>1e3) return (boost::format("%.2f kH/s") % (hr/1e3)).str();
-  return (boost::format("%.0f H/s") % hr).str();
+  return (boost::format("%.2f H/s") % hr).str();
 }
 
 static std::string get_fork_extra_info(uint64_t t, uint64_t now, uint64_t block_time)


### PR DESCRIPTION
Adds 2 digits of floating point precision to the hash rate shown in the status command to prevent it showing as 0 on low powered machines